### PR TITLE
Multiply window size by input channels dimension

### DIFF
--- a/libs/pconv_layer.py
+++ b/libs/pconv_layer.py
@@ -42,7 +42,7 @@ class PConv2D(Conv2D):
         )
 
         # Window size - used for normalization
-        self.window_size = self.kernel_size[0] * self.kernel_size[1]
+        self.window_size = self.kernel_size[0] * self.kernel_size[1] * self.input_dim
         
         if self.use_bias:
             self.bias = self.add_weight(shape=(self.filters,),


### PR DESCRIPTION
Hi, Mathias!
Please, look at the authors' implementation in PyTorch: 
_self.slide_winsize = self.weight_maskUpdater.shape[1] * self.weight_maskUpdater.shape[2] * self.weight_maskUpdater.shape[3]_
and compare with your current
_self.window_size = self.kernel_size[0] * self.kernel_size[1]_
According to the paper, the scaling factor for all valid (unmasked) pixels in window is **1**, but in your case it is **1/(input channels dimension).**
I don't think it's a big problem, this additional multiplier is constant for each layer and can be learned by the network, or even batch norm negates it :)
But if you make proposed changes to the code, old trained weights will be invalid.
