### PR TITLE
Convert kernel_mask into a constant tensor

### DIFF
--- a/libs/pconv_layer.py
+++ b/libs/pconv_layer.py
@@ -33,7 +33,7 @@ class PConv2D(Conv2D):
                                       regularizer=self.kernel_regularizer,
                                       constraint=self.kernel_constraint)
         # Mask kernel
-        self.kernel_mask = K.ones(shape=self.kernel_size + (self.input_dim, self.filters))
+        self.kernel_mask = K.constant(1, shape=self.kernel_size + (self.input_dim, self.filters))
 
         # Calculate padding size to achieve zero-padding
         self.pconv_padding = (


### PR DESCRIPTION
When I use the given implementation for training, I always get NaN values at the output. Sometimes this happens after a few training steps and sometimes after a few epochs (depending on the training data used). 

While debugging, I noticed that the `kernel_mask` was updated. I think this is because `K.ones(shape=...)` returns a trainable variable if all entries in the passed shape are >0. In the original PyTorch implementation the `kernel_mask` is initialized using `weight_maskUpdater = torch.ones(...)`, which by default creates a non-trainable tensor (since `requires_grad=False`).

After replacing `K.ones(...)` with `K.constant(...)` the NaN values no longer occur.